### PR TITLE
[Issue21] Add discriminator to APIRateCounter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 ### Fixes
 
 * Your contribution here.
+* [#24](https://github.com/darren987469/todos/pull/24): Add discriminator to APIRateCounter - [@darren987469][darren987469].
 * [#19](https://github.com/darren987469/todos/pull/19): Show encoded token after creating - [@darren987469][darren987469].
 
 [darren987469]: https://github.com/darren987469

--- a/app/apis/helper/throttle.rb
+++ b/app/apis/helper/throttle.rb
@@ -1,9 +1,10 @@
 module Helper
   module Throttle
-    def throttle(api_name, limit:, period:)
+    def throttle(api_name, **options)
       return unless token_user?
 
-      counter = APIRateCounter.add(api_name, limit, period)
+      limit = options[:limit]
+      counter = APIRateCounter.add(api_name, discriminator: access_token.id, **options)
       count = counter.increment
 
       return unless count > limit

--- a/app/services/api_rate_counter.rb
+++ b/app/services/api_rate_counter.rb
@@ -6,21 +6,19 @@ class APIRateCounter
       @redis ||= ENV['REDIS_URL'] ? Redis.new(url: ENV['REDIS_URL']) : Redis.new
     end
 
-    def apis
-      @apis ||= {}
+    def counters
+      @counters ||= APIRateCounter::Counters.new
     end
-
-    def add(api_name, limit, period)
-      apis[api_name] ||= new(api_name, limit, period)
-    end
+    delegate :add, :get, :clear, :key, to: :counters
   end
 
-  attr_reader :api_name, :limit, :period, :count
+  attr_reader :api_name, :limit, :period, :discriminator, :count
 
-  def initialize(api_name, limit, period)
+  def initialize(api_name, limit:, period:, discriminator:)
     @api_name = api_name
     @limit = limit
     @period = period
+    @discriminator = discriminator
   end
 
   def increment(amount = 1)
@@ -44,7 +42,7 @@ class APIRateCounter
   end
 
   def key
-    "#{PREFIX}:#{api_name}"
+    "#{PREFIX}:#{api_name}:#{discriminator}"
   end
 
   def redis

--- a/app/services/api_rate_counter/counters.rb
+++ b/app/services/api_rate_counter/counters.rb
@@ -1,0 +1,27 @@
+class APIRateCounter
+  class Counters
+    attr_reader :counters
+
+    def initialize
+      @counters = {}
+    end
+
+    def add(api_name, discriminator:, **options)
+      key = self.key(api_name, discriminator)
+      counters[key] ||= APIRateCounter.new(api_name, discriminator: discriminator, **options)
+    end
+
+    def get(api_name, discriminator)
+      key = self.key(api_name, discriminator)
+      counters[key]
+    end
+
+    def clear
+      @counters = {}
+    end
+
+    def key(api_name, discriminator)
+      "#{api_name}:#{discriminator}"
+    end
+  end
+end

--- a/spec/services/api_rate_counter/counters_spec.rb
+++ b/spec/services/api_rate_counter/counters_spec.rb
@@ -1,0 +1,48 @@
+require 'rails_helper'
+
+describe APIRateCounter::Counters do
+  let(:limit) { 1 }
+  let(:period) { 1.hour }
+  let(:api_name) { 'test_api' }
+  let(:discriminator) { 'token_id' }
+  let(:counter_params) { [api_name, { limit: limit, period: period, discriminator: discriminator }] }
+  let(:counters) { described_class.new }
+
+  describe '#add' do
+    context 'when counter not exists' do
+      it 'creates APIRateCounter instance and returns it' do
+        counter = counters.add(*counter_params)
+        expect(counter).to be_a_kind_of APIRateCounter
+      end
+    end
+
+    context 'when counter exists' do
+      let!(:counter) { counters.add(*counter_params) }
+
+      it 'returns APIRateCounter without create new instance' do
+        expect(APIRateCounter).not_to receive(:new)
+
+        subject = counters.add(*counter_params)
+        expect(subject).to eq counter
+      end
+    end
+  end
+
+  describe '#get' do
+    subject { counters.get(api_name, discriminator) }
+
+    context 'counter not exists' do
+      it 'returns nil' do
+        expect(subject).to be_nil
+      end
+    end
+
+    context 'counter exists' do
+      let!(:counter) { counters.add(*counter_params) }
+
+      it 'returns counter' do
+        expect(subject).to eq counter
+      end
+    end
+  end
+end

--- a/spec/services/api_rate_counter_spec.rb
+++ b/spec/services/api_rate_counter_spec.rb
@@ -4,32 +4,11 @@ describe APIRateCounter do
   let(:limit) { 1 }
   let(:period) { 1.hour }
   let(:api_name) { 'test_api' }
-  let(:counter) { described_class.new(api_name, limit, period) }
+  let(:discriminator) { 'token_id' }
+  let(:counter_params) { [api_name, { limit: limit, period: period, discriminator: discriminator }] }
+  let(:counter) { described_class.new(*counter_params) }
 
   before { described_class.redis.flushdb }
-
-  describe '.add' do
-    context 'when api not exists' do
-      it 'creates APIRateCounter instance and returns it' do
-        counter = described_class.add(api_name, limit, period)
-
-        expect(described_class.apis).to have_key(api_name)
-        expect(described_class.apis[api_name]).to eq counter
-        expect(counter).to be_a_kind_of APIRateCounter
-      end
-    end
-
-    context 'when api exists' do
-      before { described_class.add(api_name, limit, period) }
-
-      it 'returns APIRateCounter without create new instance' do
-        expect(APIRateCounter).not_to receive(:new)
-
-        counter = described_class.add(api_name, limit, period)
-        expect(counter.api_name).to eq api_name
-      end
-    end
-  end
 
   describe '#increment' do
     it 'default increment count by 1' do


### PR DESCRIPTION
Discriminator is used to distinguishing different users' usage of API.