### PR TITLE
Fix rate limit info in response header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixes
 
 * Your contribution here.
+* [#31](https://github.com/darren987469/todos/pull/31): Fix rate limit info in response header - [@darren987469][darren987469]
 * [#30](https://github.com/darren987469/todos/pull/30): Limit API rate by token user - [@darren987469][darren987469]
 * [#27](https://github.com/darren987469/todos/pull/27): Separate internal, public API - [@darren987469][darren987469]
 

--- a/app/apis/helper/throttle.rb
+++ b/app/apis/helper/throttle.rb
@@ -8,13 +8,11 @@ module Helper
       counter = APIRateCounter.get_or_add(options)
       count = counter.increment
 
-      return unless count > limit
-
       header('X-RateLimit-Limit', limit)
       header('X-RateLimit-Remaining', counter.remaining)
       header('X-RateLimit-Reset', counter.reset_at.to_i)
 
-      raise RateLimitExceededError
+      raise RateLimitExceededError if count > limit
     end
   end
 end

--- a/doc/api_reference.md
+++ b/doc/api_reference.md
@@ -13,16 +13,16 @@ curl -H "Authorization: token [TOKEN]" https://todos-actioncable.herokuapp.com
 Requests that return multiple items will be paginated to 10 items by default. You can specify further pages with `?page` parameter. You can also set a page size up to 100 the `?per_page` parameter.
 
 ```javascript
-// curl https://todos-actioncable.heroku.com/api/v1/logs?page=2&per_page=100
+// curl https://todos-actioncable.herokuapp.com/api/v1/todo_lists/1/logs?page=2&per_page=100
 {
   "results": [
     // items
   ],
   "links": {
-    "first": "https://todos-actioncable.heroku.com/api/v1/logs?page=1&per_page=100",
-    "prev": "https://todos-actioncable.heroku.com/api/v1/logs?page=1&per_page=100",
-    "next": "https://todos-actioncable.heroku.com/api/v1/logs?page=3&per_page=100",
-    "last": "https://todos-actioncable.heroku.com/api/v1/logs?page=4&per_page=100",
+    "first": "https://todos-actioncable.herokuapp.com/api/v1/todo_lists/1/logs?page=1&per_page=100",
+    "prev": "https://todos-actioncable.herokuapp.com/api/v1/todo_lists/1/logs?page=1&per_page=100",
+    "next": "https://todos-actioncable.herokuapp.com/api/v1/todo_lists/1/logs?page=3&per_page=100",
+    "last": "https://todos-actioncable.herokuapp.com/api/v1/todo_lists/1/logs?page=4&per_page=100",
   },
   "page": 2,
   "per_page": 100
@@ -30,3 +30,23 @@ Requests that return multiple items will be paginated to 10 items by default. Yo
 ```
 
 Note that page number is 1-based and that omitting the `?page` parameter will return the first page.
+
+## Rate limiting
+
+For API requests using token, you can make up to 5000 requests per hour. Authenticated requests are associated with the authenticated user. This means that all applications authorized by a user share the same quota of 5000 requests per hour when they authenticate with different tokens owned by the same user.
+
+The returned HTTP header of any API request show you current rate limit status:
+
+```sh
+curl -i https://todos-actioncable.herokuapp.com/api/v1/todo_lists/1/logs
+HTTP/1.1 200 OK
+X-RateLimit-Limit: 5000
+X-RateLimit-Remaining: 4998
+X-RateLimit-Reset: 1543396712
+```
+
+Header Name | Description
+------------|-------------
+`X-RateLimit-Limit` | The maximum number of requests you're permitted to make per hour.
+`X-RateLimit-Remaining` | The number of requests remaining in the current rate limit window.
+`X-RateLimit-Reset` | The time at which the current rate limit window resets in UTC epoch seconds.


### PR DESCRIPTION
Add rate limit info in the response header.
Add rate limit section in API reference.